### PR TITLE
Please consider the following 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,43 @@ remote.add_interface("My-Mod-Interface", interface)
  suck if your internal state got out of sync with what the player expected.)
 
 
-- finally, and most importantly, your mod needs to register with WrenchFu in
-`on_init` and `on_load` (the registry is not persistent):
+- finally, and most importantly, your mod needs to register with WrenchFu. WrenchFu has the following interface:
+```Lua
+register=function(entity_name, handler_param)
+    --[[this one registers the handler, which is going to be called when player uses Wrench onto the entity_name
+        handler_param is the following table
+        {
+            mod_name = mod_name,--name of your interface (mandatory)
+            show_method = show_method, 
+            --[[name of function in your interface, which should be called whe entity_name is wrenched (mandatory)
+            is function(player_index, entity), entity is game object here
+            ]]
+            hide_method = hide_method,
+            --[[name of function to call when wrench is used on empty ground or player moved too far or a specific other entity if clicked with wrench 
+            is function(player_index, entity_name, entity_position)
+            must return true if it is allowed to close the gui
+            ]]
+            max_distance = max_distance,
+            --max distance player can move away from entity before gui is closed, if nil - unlimited
+            no_interlace_with = no_interlace_with 
+            --[[names of other entities, which guis should be closed when gui for this entity is opened
+            will always attempt to close gui for the same named entity.
+            ]]
+        }
+    ]]
+    close=function(player_index,entity_name)
+    --[[should be called when your gui is closed not by WrenchFu facilities.
+    cleans up the related data in this mod
+    ]]
+    ```
+-Thus to register your entity, you need to put the following into `on_init` and `on_load` (or just into body of control.lua):
 
 ```Lua
-script.on_init(function()
-    remote.call("WrenchFu", "register", "my-machine-name", "My-Mod-Interface", "show_my_gui", "hide_my_gui")
-end)
-
-script.on_load(function()
-    remote.call("WrenchFu", "register", "my-machine-name", "My-Mod-Interface", "show_my_gui", "hide_my_gui")
-end)
+    remote.call("WrenchFu", "register", "my-machine-name", {
+        mod_name = "My-Mod-Interface", 
+        show_method = "show_my_gui",
+        hide_method = "hide_my_gui",
+        max_distance = 30})
 ```
 
 And that's all (from WrenchFu's point of view, at least).

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ register=function(entity_name, handler_param)
     --[[should be called when your gui is closed not by WrenchFu facilities.
     cleans up the related data in this mod
     ]]
-    ```
+```
 -Thus to register your entity, you need to put the following into `on_init` and `on_load` (or just into body of control.lua):
 
 ```Lua

--- a/WrenchFu/gui.lua
+++ b/WrenchFu/gui.lua
@@ -33,7 +33,7 @@ function WrenchFu.close_gui_for(player_index,entity_name)
     local gui_data = global.open_guis[player_index][entity_name]
 
     local reg = gui_data.handler
-    remote.call(reg.mod_name, reg.hide_method, player_index, gui_data.entity_name, gui_data.position)
+    remote.call(reg.mod_name, reg.hide_method, player_index, entity_name, gui_data.position)
 
     global.open_guis[player_index][entity_name] = nil
 end
@@ -82,7 +82,7 @@ function WrenchFu.on_tick(event)
             for entity_name,gui_data in pairs(global.open_guis[player_index]) do
                 if not gui_data.handler.max_distance then 
                     if util.distance(player.position, gui_data.position) > gui_data.handler.max_distance then
-                        WrenchFu.close_gui_for(player_index)
+                        WrenchFu.close_gui_for(player_index,entity_name)
                     end
                 end
             end

--- a/WrenchFu/gui.lua
+++ b/WrenchFu/gui.lua
@@ -78,13 +78,12 @@ function WrenchFu.on_tick(event)
     if not global.open_guis then global.open_guis = {} end
 
     for player_index, player in pairs(game.players) do
-        if global.open_guis[player_index] == nil then return end
-        local guis = global.open_guis[player_index]
-        
-        for entity_name,gui_data in pairs(guis) do
-            if not gui_data.handler.max_distance then 
-                if util.distance(player.position, gui_data.position) > gui_data.handler.max_distance then
-                    WrenchFu.close_gui_for(player_index)
+        if global.open_guis[player_index] then 
+            for entity_name,gui_data in pairs(global.open_guis[player_index]) do
+                if not gui_data.handler.max_distance then 
+                    if util.distance(player.position, gui_data.position) > gui_data.handler.max_distance then
+                        WrenchFu.close_gui_for(player_index)
+                    end
                 end
             end
         end

--- a/WrenchFu/registry.lua
+++ b/WrenchFu/registry.lua
@@ -5,19 +5,26 @@ WrenchFu's registry: keeps the wrenchable handler registry.
 if not WrenchFu then WrenchFu = {} end
 local handler_registry = {}
 
-
 interface = {}
-function interface.register(entity_name, mod_name, show_method, hide_method)
+function interface.register(entity_name, mod_name, show_method, hide_method, max_distance,no_interlace_with)
     local handler = handler_registry[entity_name]
     if handler ~= nil and handler.mod_name ~= mod_name then
         WrenchFu.notify_all({"warn_stealing_registry", entity_name, handler.mod_name, mod_name})
     end
-
+    
+    no_interlace_with = no_interlace_with or {}
+    no_interlace_with.[entity_name]=true
+    
     handler_registry[entity_name] = {
         mod_name = mod_name,
         show_method = show_method,
         hide_method = hide_method,
+        max_distance = max_distance,
+        no_interlace_with = no_interlace_with 
     }
+    if max_distance and  ( ( not WrenchFu.max_distance) or WrenchFu.max_distance < max_distance ) then
+        WrenchFu.max_distance = max_distance
+    end
 end
 remote.add_interface("WrenchFu", interface)
 

--- a/WrenchFu/registry.lua
+++ b/WrenchFu/registry.lua
@@ -6,25 +6,30 @@ if not WrenchFu then WrenchFu = {} end
 local handler_registry = {}
 
 interface = {}
-function interface.register(entity_name, mod_name, show_method, hide_method, max_distance,no_interlace_with)
+function interface.register(entity_name, handler_params)
+    
     local handler = handler_registry[entity_name]
-    if handler ~= nil and handler.mod_name ~= mod_name then
-        WrenchFu.notify_all({"warn_stealing_registry", entity_name, handler.mod_name, mod_name})
+    if handler ~= nil and handler.mod_name ~= handler_params.mod_name then
+        WrenchFu.notify_all({"warn_stealing_registry", entity_name, handler.mod_name, handler_params.mod_name})
+    end
+    handler = handler_params
+    if not handler.mod_name or not remote.interfaces[handler.mod_name] then
+        WrenchFu.notify_all({"error_no_interface name", entity_name}) end
+    if not handler.show_method or not remote.interfaces[handler.mod_name][handler.show_method] then
+        WrenchFu.notify_all({"error_no_function_to_call", entity_name, handler_params.mod_name}) 
     end
     
-    no_interlace_with = no_interlace_with or {}
-    no_interlace_with[entity_name]=true
+    handler.no_interlace_with = handler.no_interlace_with or {}
+    handler.no_interlace_with[entity_name]=true
     
-    handler_registry[entity_name] = {
-        mod_name = mod_name,
-        show_method = show_method,
-        hide_method = hide_method,
-        max_distance = max_distance,
-        no_interlace_with = no_interlace_with 
-    }
+    handler_registry[entity_name] = handler
+    
     if max_distance and  ( ( not WrenchFu.max_distance) or WrenchFu.max_distance < max_distance ) then
         WrenchFu.max_distance = max_distance
     end
+end
+function interface.close(player_index,entity_name)
+    return WrenchFu.close_gui_unconditionally(player_index,entity_name)
 end
 remote.add_interface("WrenchFu", interface)
 

--- a/WrenchFu/registry.lua
+++ b/WrenchFu/registry.lua
@@ -13,7 +13,7 @@ function interface.register(entity_name, mod_name, show_method, hide_method, max
     end
     
     no_interlace_with = no_interlace_with or {}
-    no_interlace_with.[entity_name]=true
+    no_interlace_with[entity_name]=true
     
     handler_registry[entity_name] = {
         mod_name = mod_name,

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -1,5 +1,7 @@
 error_event = [WrenchFu|__1__] Error: __2__
 warn_stealing_registry=[WrenchFu] Warning: The mod __3__ is stealing the wrenchable registration for __1__, originally handled by __2__. This will be allowed.
+error_no_interface_name= [WrenchFu] Error: Some mod attempted to registed handler for __1__ but the interface to call is not provided
+error_no_function_to_call= [WrenchFu] Error: The interface __2__ is registed handler for __1__ but there is no handler function 
 
 [item-name]
 wrenchfu-wrench=Wrench


### PR DESCRIPTION
I'd like to present my modification of the code. 

Max distance id changed to per-entity parameter.
The close gui is now not unconditional shutdown, the client mod should handle the situation and then tell Wrench whether gui is closed or not yet.
Guis for unrelated entities can now be opened in parallel. 
The handler is called with player_index and entity.
Sadly, the compatibility is broken.
